### PR TITLE
remove failure crate usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,11 @@ display = []
 integration_tests = []
 
 [dependencies]
+anyhow = "1"
 log = "0.4"
 libc = "0.2"
 byteorder = "1.3"
-failure = "0.1"
+thiserror = "1"
 uuid = "0.8"
 time = "0.2"
 bitflags = "1.0"

--- a/examples/otool.rs
+++ b/examples/otool.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate log;
 
 use std::env;
@@ -14,8 +12,8 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::rc::Rc;
 
+use anyhow::{Error, bail, anyhow};
 use byteorder::ReadBytesExt;
-use failure::Error;
 use memmap::Mmap;
 use structopt::StructOpt;
 
@@ -114,12 +112,12 @@ struct Opt {
 fn parse_cpu_type(arch: &str) -> Result<cpu_type_t, Error> {
     get_arch_from_flag(arch)
         .map(|&(cpu_type, _)| cpu_type)
-        .ok_or_else(|| format_err!("unknown architecture specification flag: arch {}", arch))
+        .ok_or_else(|| anyhow!("unknown architecture specification flag: arch {}", arch))
 }
 
 fn parse_section(s: &str) -> Result<(String, Option<String>), Error> {
     let mut names = s.splitn(2, ':');
-    let segname = names.next().ok_or_else(|| format_err!("missing section name"))?;
+    let segname = names.next().ok_or_else(|| anyhow!("missing section name"))?;
     let sectname = names.next().map(|s| s.to_owned());
 
     Ok((segname.to_owned(), sectname))

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,8 +6,8 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
 
+use anyhow::Error;
 use byteorder::{ByteOrder, ReadBytesExt};
-use failure::Error;
 use uuid::Uuid;
 
 use crate::consts::*;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,47 +3,37 @@ use std::num;
 use std::str;
 use std::string;
 
-use failure::Error;
+use anyhow::Error;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum MachError {
-    #[fail(display = "fail to interpret a sequence of u8 as a string, {}.", _0)]
-    Utf8Error(#[cause] str::Utf8Error),
-    #[fail(display = "fail to convert a String from a UTF-8 byte vector, {}.", _0)]
-    FromUtf8Error(#[cause] string::FromUtf8Error),
-    #[fail(display = "fail to parse UUID, {}.", _0)]
+    #[error("fail to interpret a sequence of u8 as a string, {}.", _0)]
+    Utf8Error(#[from] str::Utf8Error),
+    #[error("fail to convert a String from a UTF-8 byte vector, {}.", _0)]
+    FromUtf8Error(#[from] string::FromUtf8Error),
+    #[error("fail to parse UUID, {}.", _0)]
     UuidError(::uuid::Error),
-    #[fail(display = "fail to do I/O operations, {}.", _0)]
-    IoError(#[cause] io::Error),
-    #[fail(display = "fail to parse time, {}.", _0)]
-    TimeParseError(#[cause] time::ParseError),
-    #[fail(display = "fail to parse integer, {}.", _0)]
-    ParseIntError(#[cause] num::ParseIntError),
-    #[fail(display = "fail to parse octal, {}.", _0)]
+    #[error("fail to do I/O operations, {}.", _0)]
+    IoError(#[from] io::Error),
+    #[error("fail to parse time, {}.", _0)]
+    TimeParseError(#[from] time::ParseError),
+    #[error("fail to parse integer, {}.", _0)]
+    ParseIntError(#[from] num::ParseIntError),
+    #[error("fail to parse octal, {}.", _0)]
     ParseOctalError(String),
-    #[fail(display = "unknown file format, magic 0x{:08x}.", _0)]
+    #[error("unknown file format, magic 0x{:08x}.", _0)]
     UnknownMagic(u32),
-    #[fail(display = "unknown symbol type, {}.", _0)]
+    #[error("unknown symbol type, {}.", _0)]
     UnknownSymType(u8),
-    #[fail(display = "offset {} out of range: [0..{}).", _0, _1)]
+    #[error("offset {} out of range: [0..{}).", _0, _1)]
     OutOfRange(usize, usize),
-    #[fail(display = "number overflowing.")]
+    #[error("number overflowing.")]
     NumberOverflow,
-    #[fail(display = "buffer overflowing, {}.", _0)]
+    #[error("buffer overflowing, {}.", _0)]
     BufferOverflow(usize),
 }
 
-impl From<str::Utf8Error> for MachError {
-    fn from(err: str::Utf8Error) -> Self {
-        MachError::Utf8Error(err)
-    }
-}
-
-impl From<string::FromUtf8Error> for MachError {
-    fn from(err: string::FromUtf8Error) -> Self {
-        MachError::FromUtf8Error(err)
-    }
-}
 
 impl From<uuid::Error> for MachError {
     fn from(err: uuid::Error) -> Self {
@@ -51,22 +41,5 @@ impl From<uuid::Error> for MachError {
     }
 }
 
-impl From<io::Error> for MachError {
-    fn from(err: io::Error) -> Self {
-        MachError::IoError(err)
-    }
-}
-
-impl From<time::ParseError> for MachError {
-    fn from(err: time::ParseError) -> Self {
-        MachError::TimeParseError(err)
-    }
-}
-
-impl From<num::ParseIntError> for MachError {
-    fn from(err: num::ParseIntError) -> Self {
-        MachError::ParseIntError(err)
-    }
-}
 
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,6 @@
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,10 +1,10 @@
-use std::io::{Cursor};
+use std::io::Cursor;
 use std::rc::Rc;
 use std::str;
 
 use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
 
-use crate::commands::{Section};
+use crate::commands::Section;
 use crate::consts::*;
 use crate::errors::*;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -9,7 +9,7 @@ use std::io::{self, Cursor};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
-use failure::Error;
+use anyhow::Error;
 use hexplay::HexViewBuilder;
 use memmap::Mmap;
 use pretty_env_logger;


### PR DESCRIPTION
Hey!
Thanks for the crate. The failure crate is deprecated and now GitHub reports there's a security issue there so we want it fixed for our project :)
I introduced usage of anyhow & thiserror to replace the failure crate.. the use of anyhow for a crate is a bit crappy, but I didn't want to introduce too many changes.

