### PR TITLE
fix unreachable panic when parsing export table

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,8 @@ pub enum Error {
     UnknownMagic(u32),
     #[error("unknown symbol type, {0}.")]
     UnknownSymType(u8),
+    #[error("unknown export symbol kind, {0}.")]
+    UnknownExportSymKind(u8),
     #[error("offset {0} out of range: {1:?}.")]
     OutOfRange(usize, Range<usize>),
     #[error("number overflowing.")]

--- a/src/export.rs
+++ b/src/export.rs
@@ -3,8 +3,8 @@ use std::io::Cursor;
 use byteorder::ReadBytesExt;
 
 use crate::commands::CursorExt;
-use crate::consts::*;
 use crate::errors::{Error::*, Result};
+use crate::{consts::*, MachError};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ExportKind {
@@ -41,7 +41,7 @@ impl Exported {
                 EXPORT_SYMBOL_FLAGS_KIND_REGULAR => ExportKind::Regular,
                 EXPORT_SYMBOL_FLAGS_KIND_THREAD_LOCAL => ExportKind::ThreadLocal,
                 EXPORT_SYMBOL_FLAGS_KIND_ABSOLUTE => ExportKind::Absolute,
-                _ => unreachable!(),
+                invalid => return Err(MachError::UnknownExportSymKind(invalid)),
             };
 
             let flags = ExportSymbolFlags::from_bits_truncate(flags as u32);


### PR DESCRIPTION
Found this issue when fuzzing the crate.

The export symbol flag kind uses that last two bits of `flags`, and therefore can take 4 values. Only 3 are officially defined in the `ExportSymbolKind` enum.

Malformed macho files can define a symbol kind of 0b11 and will cause this crate to panic when parsing them.

Avoid panicking, and return a new error kind instead.