### PR TITLE
fix stack overflow on recursive export trie

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,6 +33,8 @@ pub enum Error {
     NumberOverflow,
     #[error("buffer overflowing, {0}.")]
     BufferOverflow(usize),
+    #[error("recursive export trie at offset {0}.")]
+    RecursiveExportTrie(u64),
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;


### PR DESCRIPTION
Found this bug when fuzzing the crate

When the export trie is malformed and is recursive, `Exported::parse()` will stack overflow when trying to parse it.

Detect this condition and return an error instead. This is implemented by remembering the list of parent nodes that we visited in the trie, and erroring if we ever try to visit the same node a second time.

I initially tried to implement it by ensuring that the Cursor always makes forward progress when parsing the trie, but some valid binaries, e.g. /usr/bin/smbd layout their trie in a way that requires to sometime jump backwards to get the child nodes.